### PR TITLE
Pull dataset name from message subject instead of body

### DIFF
--- a/dotnet/IrisClient/MessageProcessors.cs
+++ b/dotnet/IrisClient/MessageProcessors.cs
@@ -27,16 +27,8 @@ public class MessageProcessors
 
         var baseDownloadDirectory = FileDownloadHelpers.GetDownloadDirectory();
 
-        string dataset;
-        try
-        {
-            dataset = node[0]?["dataset"]?.ToString() ?? "unknown";
-        }
-        catch // `node[0]` could throw ArgumentOutOfRangeException or InvalidOperationException
-        {
-            dataset = "unknown";
-        }
-
+        var dataset = args.Message.Subject ?? "unknown";
+        
         var path = Path.Combine(baseDownloadDirectory, _relativeDownloadDirectory, dataset);
         var time = DateTime.Now.ToString("yyyy-MM-ddTHH-mm-ss_fff");
         var filename = $"{dataset}_{time}.json";

--- a/nodeJs/processors/processMessage.js
+++ b/nodeJs/processors/processMessage.js
@@ -29,11 +29,7 @@ const processMessage = async (messageReceived) => {
   console.log("Processing message");
 
   const body = JSON.parse(messageReceived.body);
-  const dataset = body?.[0]?.dataset;
-
-  if (!dataset) {
-    throw new Error("Unable to find dataset in message");
-  }
+  const dataset = messageReceived.subject ?? "unknown";
 
   const content = JSON.stringify(body, null, 2);
   createFile(dataset, content);

--- a/python/client.py
+++ b/python/client.py
@@ -35,7 +35,7 @@ def get_authenticated_sevice_bus_client(settings: Settings):
 def save_message(msg: ServiceBusReceivedMessage, download_directory):
     raw_json_s = ast.literal_eval(str(msg))
     raw_json = json.loads(raw_json_s)
-    dataset = raw_json[0]['dataset'] or 'unknown'
+    dataset = msg.subject or 'unknown'
     file_name = f'{dataset}_{datetime.now().strftime("%y%m%dT%H%M%S_%f")}.json'
     output_folder_path = os.path.join(download_directory, dataset)
     output_file_path = os.path.join(output_folder_path, file_name)


### PR DESCRIPTION
Currently our clients pull the dataset from an IRIS message by inspecting the `dataset` field of the first element in what we assume to be an array. The dataset is now available in the message subject, which is a more reliable source.

This PR updates the example clients to read this message subject rather than the message content to find the dataset.